### PR TITLE
Fix document name

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -34,7 +34,7 @@ $(function () {
 
     //This code will create and/or open a Sync document
     //Note the use of promises
-    syncClient.document('sync.game').then(function(doc) {
+    syncClient.document('SyncGame').then(function(doc) {
       //Lets store it in our global variable
       syncDoc = doc;
 


### PR DESCRIPTION
Currently document unique name containing dot is not supported on REST API. Changing name so that people could access the document created by QuickStart over REST API by name.
